### PR TITLE
feat: add copy button for assistant messages

### DIFF
--- a/apps/client/src/components/messages.tsx
+++ b/apps/client/src/components/messages.tsx
@@ -102,9 +102,9 @@ const CopyAssistantMessageButton = ({ content }: { content: string }) => {
     const [copied, setCopied] = useState(false);
 
     const copyToClipboard = async () => {
-        const { isOk } = await tryCatch(navigator.clipboard.writeText(content));
+        const result = await tryCatch(navigator.clipboard.writeText(content));
 
-        if (isOk()) {
+        if (result.isOk()) {
             setCopied(true);
             setTimeout(() => {
                 setCopied(false);

--- a/apps/client/src/components/messages.tsx
+++ b/apps/client/src/components/messages.tsx
@@ -98,6 +98,38 @@ const Code: Component = ({ children, className }) => {
 };
 const Pre = ({ children }: PropsWithChildren) => <>{children}</>;
 
+const CopyAssistantMessageButton = ({ content }: { content: string }) => {
+    const [copied, setCopied] = useState(false);
+
+    const copyToClipboard = async () => {
+        const { isOk } = await tryCatch(navigator.clipboard.writeText(content));
+
+        if (isOk()) {
+            setCopied(true);
+            setTimeout(() => {
+                setCopied(false);
+            }, 2000);
+        }
+    };
+
+    return (
+        <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => {
+                void copyToClipboard();
+            }}
+            aria-label="Copy message"
+        >
+            {copied ? (
+                <Check className="h-4 w-4" />
+            ) : (
+                <Copy className="h-4 w-4" />
+            )}
+        </Button>
+    );
+};
+
 export function Messages({ messages }: Props) {
     return messages.map(({ role, content, model }, index) => {
         if (role === "assistant") {
@@ -112,14 +144,17 @@ export function Messages({ messages }: Props) {
                             Using model: {model}
                         </div>
                     )}
-                    <Markdown
-                        components={{
-                            code: Code,
-                            pre: Pre,
-                        }}
-                    >
-                        {content}
-                    </Markdown>
+                    <div data-testid="assistant-message-content">
+                        <Markdown
+                            components={{
+                                code: Code,
+                                pre: Pre,
+                            }}
+                        >
+                            {content}
+                        </Markdown>
+                    </div>
+                    <CopyAssistantMessageButton content={content} />
                 </div>
             );
         }

--- a/tests/web/copy-button.spec.ts
+++ b/tests/web/copy-button.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "@playwright/test";
+import { waitForAssistantToStopStreaming } from "./utils";
+
+test("copy button copies message content", async ({ page }) => {
+    // Grant clipboard permissions if supported
+    const browserName = page.context().browser()?.browserType().name();
+
+    if (browserName === "chromium") {
+        await page
+            .context()
+            .grantPermissions(["clipboard-read", "clipboard-write"]);
+    } else if (browserName === "webkit") {
+        // WebKit doesn't support 'clipboard-write'; only grant 'clipboard-read'
+        await page.context().grantPermissions(["clipboard-read"]);
+    }
+
+    await page.goto("/");
+    await page.waitForSelector('[data-testid="message-input"]');
+
+    const testMessage = "Hello, can you help me with a simple test?";
+    await page.fill('[data-testid="message-input"]', testMessage);
+    await page.press('[data-testid="message-input"]', "Enter");
+
+    // Wait for assistant to finish streaming
+    const messageContent = await waitForAssistantToStopStreaming(page);
+    expect(messageContent).toBeTruthy();
+
+    const copyButton = page.locator('[aria-label="Copy message"]');
+    await expect(copyButton).toBeVisible();
+
+    await copyButton.click();
+
+    // Wait a bit for the clipboard to be updated
+    await page.waitForTimeout(1000);
+
+    // Only verify clipboard content if permissions were granted
+    const copiedText = await page.evaluate(() => {
+        return navigator.clipboard.readText();
+    });
+    expect(copiedText).toBe(messageContent);
+});

--- a/tests/web/example.spec.ts
+++ b/tests/web/example.spec.ts
@@ -35,13 +35,13 @@ test("can send message to AI assistant and receive response", async ({
     await expect(userMessage).toContainText(testMessage);
 
     // Wait for any response from the assistant to appear
-    await page.waitForSelector('[data-testid="assistant-message"]', {
+    await page.waitForSelector('[data-testid="assistant-message-content"]', {
         timeout: 2_000,
     });
 
     // Verify that the assistant response contains some text
     const assistantResponse = page
-        .locator('[data-testid="assistant-message"]')
+        .locator('[data-testid="assistant-message-content"]')
         .first();
     await expect(assistantResponse).toBeVisible();
 

--- a/tests/web/tsconfig.json
+++ b/tests/web/tsconfig.json
@@ -4,7 +4,7 @@
     "compilerOptions": {
         "moduleResolution": "bundler",
         /* If your code doesn't run in the DOM: */
-        "lib": ["es2022"],
+        "lib": ["es2022", "dom"],
 
         "types": ["@playwright/test", "node"],
 

--- a/tests/web/tsconfig.json
+++ b/tests/web/tsconfig.json
@@ -3,7 +3,7 @@
 
     "compilerOptions": {
         "moduleResolution": "bundler",
-        /* If your code doesn't run in the DOM: */
+
         "lib": ["es2022", "dom"],
 
         "types": ["@playwright/test", "node"],

--- a/tests/web/utils.ts
+++ b/tests/web/utils.ts
@@ -1,0 +1,43 @@
+import { Page, expect } from "@playwright/test";
+
+/**
+ * Waits for the assistant to stop streaming a message by monitoring content changes
+ * @param page Playwright page
+ * @param thresholdMs Time in milliseconds to wait for no changes before considering streaming complete
+ * @param startTimeoutMs Time in milliseconds to wait for assistant to start streaming
+ * @returns The final message content
+ * @throws Error if the message content cannot be found or if streaming doesn't start within timeout
+ */
+export async function waitForAssistantToStopStreaming(
+    page: Page,
+    thresholdMs = 1000,
+    startTimeoutMs = 3000
+): Promise<string> {
+    const messageLocator = page
+        .locator('[data-testid="assistant-message-content"]')
+        .first();
+    const POLL_INTERVAL_MS = 100;
+
+    // Wait for initial content with timeout
+    await expect(messageLocator).toContainText(/./, {
+        timeout: startTimeoutMs,
+    });
+
+    let lastContent = await messageLocator.textContent();
+    let lastChangeTime = Date.now();
+
+    // Use a more structured polling approach
+    while (Date.now() - lastChangeTime < thresholdMs) {
+        await page.waitForTimeout(POLL_INTERVAL_MS);
+
+        const currentContent = await messageLocator.textContent();
+
+        if (currentContent !== lastContent) {
+            lastContent = currentContent;
+            lastChangeTime = Date.now();
+        }
+    }
+
+    const finalContent = await messageLocator.textContent();
+    return finalContent ?? "";
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a copy button to assistant messages, allowing users to easily copy the full message content to the clipboard.

- **Bug Fixes**
  - Improved test selectors for assistant message content to ensure more accurate targeting in automated tests.

- **Tests**
  - Introduced automated tests to verify the copy button functionality across different browsers.
  - Added a utility function for reliably detecting when assistant message streaming has finished in tests.

- **Chores**
  - Updated TypeScript configuration to support DOM type definitions in test files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->