### PR TITLE
fix: don't send message while streaming

### DIFF
--- a/apps/client/src/api.ts
+++ b/apps/client/src/api.ts
@@ -2,8 +2,13 @@ import { ConversationReqBody, ROLES, SSE_EVENTS } from "@convo-ai/shared";
 import { env } from "@/env";
 import { PostEventSource } from "@/lib/PostEventSource.ts";
 import { db } from "@/lib/db.ts";
+import { useStreamingStore } from "@/store/streaming";
 
 export async function chat(conversationId: string, body: ConversationReqBody) {
+    const { setStreaming } = useStreamingStore.getState();
+
+    setStreaming(true);
+
     const eventSource = new PostEventSource(
         `${env.CLIENT_API_DOMAIN ?? ""}/conversation`,
         {
@@ -61,6 +66,7 @@ export async function chat(conversationId: string, body: ConversationReqBody) {
     eventSource.addEventListener(SSE_EVENTS.MESSAGE, (event) => {
         if (event.data === "[DONE]") {
             eventSource.close();
+            setStreaming(false);
         }
     });
 

--- a/apps/client/src/components/conversation-view.tsx
+++ b/apps/client/src/components/conversation-view.tsx
@@ -6,12 +6,15 @@ import { chat } from "@/api.ts";
 import { MessageForm, type OnSubmit } from "@/components/message-form";
 import { Messages } from "@/components/messages";
 import { db } from "@/lib/db.ts";
+import { useStreamingStore } from "@/store/streaming";
 
 export function ConversationView() {
     const navigate = useNavigate();
     const { conversationId } = useParams<{ conversationId?: string }>();
 
     invariant(conversationId, "conversationId must be defined");
+
+    const isStreaming = useStreamingStore.getState().isStreaming;
 
     useEffect(() => {
         void db.conversations.get(conversationId).then((conversation) => {
@@ -30,6 +33,11 @@ export function ConversationView() {
     );
 
     const handleSubmit: OnSubmit = async ({ content, model }) => {
+        if (isStreaming) {
+            console.warn("Cannot submit while streaming is active");
+            return;
+        }
+
         const messageId = crypto.randomUUID();
 
         await db.transaction("rw", db.conversations, db.messages, async () => {

--- a/apps/client/src/store/streaming.ts
+++ b/apps/client/src/store/streaming.ts
@@ -1,0 +1,22 @@
+import { create } from "zustand";
+
+type StreamingState = {
+    streaming: boolean;
+    setStreaming: (isStreaming: boolean) => void;
+};
+
+export const useStreamingStore = create<StreamingState>((set) => ({
+    streaming: false,
+
+    setStreaming: (isStreaming: boolean) => {
+        set(() => ({
+            streaming: isStreaming,
+        }));
+    },
+}));
+
+export const useStreamingActions = () => {
+    return useStreamingStore((state) => ({
+        setStreaming: state.setStreaming,
+    }));
+};


### PR DESCRIPTION
# Prevent Multiple Concurrent AI Requests

## Problem
Currently, users can send multiple messages while waiting for an AI response, which can lead to:
- Race conditions in the conversation flow
- Confusing user experience
- Potential server overload
- Inconsistent conversation state

## Changes
- Prevented message submission during active streaming