### PR TITLE
fix: prevent multiple concurrent AI requests

### DIFF
--- a/apps/client/src/api.ts
+++ b/apps/client/src/api.ts
@@ -2,8 +2,13 @@ import { ConversationReqBody, ROLES, SSE_EVENTS } from "@convo-ai/shared";
 import { env } from "@/env";
 import { PostEventSource } from "@/lib/PostEventSource.ts";
 import { db } from "@/lib/db.ts";
+import { useStreamingStore } from "@/store/streaming";
 
 export async function chat(conversationId: string, body: ConversationReqBody) {
+    const { setStreaming } = useStreamingStore.getState();
+
+    setStreaming(true);
+
     const eventSource = new PostEventSource(
         `${env.CLIENT_API_DOMAIN ?? ""}/api/conversation`,
         {
@@ -61,6 +66,7 @@ export async function chat(conversationId: string, body: ConversationReqBody) {
     eventSource.addEventListener(SSE_EVENTS.MESSAGE, (event) => {
         if (event.data === "[DONE]") {
             eventSource.close();
+            setStreaming(false);
         }
     });
 

--- a/apps/client/src/store/streaming.ts
+++ b/apps/client/src/store/streaming.ts
@@ -1,0 +1,22 @@
+import { create } from "zustand";
+
+type StreamingState = {
+    streaming: boolean;
+    setStreaming: (isStreaming: boolean) => void;
+};
+
+export const useStreamingStore = create<StreamingState>((set) => ({
+    streaming: false,
+
+    setStreaming: (isStreaming: boolean) => {
+        set(() => ({
+            streaming: isStreaming,
+        }));
+    },
+}));
+
+export const useStreamingActions = () => {
+    return useStreamingStore((state) => ({
+        setStreaming: state.setStreaming,
+    }));
+};


### PR DESCRIPTION
## Problem
Currently, users can send multiple messages while waiting for an AI response, which can lead to:
- Race conditions in the conversation flow
- Confusing user experience
- Potential server overload
- Inconsistent conversation state

## Changes
- Prevented message submission during active streaming